### PR TITLE
Add `swnt new religion` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ All commands can be queried for their available options with the -h flag. For ex
       npc         Generate a NPC
       place       Generate a place
       poi         Generate a Point of Interest
+      religion    Generate a Religion
       sector      Create the skeleton of a Sector
       world       Generate a secondary World for a Sector cell
 

--- a/cmd/religion.go
+++ b/cmd/religion.go
@@ -1,0 +1,44 @@
+// Copyright © 2018 Jeremy Friesen <jeremy.n.friesen@gmail.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/nboughton/swnt/gen/religion"
+	"github.com/spf13/cobra"
+)
+
+// religionCmd represents the religion command
+var religionCmd = &cobra.Command{
+	Use:   "religion",
+	Short: "Generate a Religion",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		fmt.Fprintln(tw, religion.New())
+		tw.Flush()
+	},
+}
+
+func init() {
+	newCmd.AddCommand(religionCmd)
+}

--- a/gen/religion/religion.go
+++ b/gen/religion/religion.go
@@ -1,0 +1,38 @@
+package religion
+
+import (
+	"bytes"
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+// Religion
+type Religion struct {
+	Evolution       string
+	Leadership      string
+	OriginTradition string
+}
+
+// New Religion with random characteristics
+func New() Religion {
+	religion := Religion{
+		Evolution:       Evolution.Roll(),
+		Leadership:      Leadership.Roll(),
+		OriginTradition: OriginTradition.Roll(),
+	}
+	return religion
+}
+
+func (religion Religion) String() string {
+	buf := new(bytes.Buffer)
+
+	fmt.Fprintf(buf, "%s\t:\t%s\n", Evolution.Name, religion.Evolution)
+	fmt.Fprintf(buf, "%s\t:\t%s\n", Leadership.Name, religion.Leadership)
+	fmt.Fprintf(buf, "%s\t:\t%s", OriginTradition.Name, religion.OriginTradition)
+	return buf.String()
+}

--- a/gen/religion/table.go
+++ b/gen/religion/table.go
@@ -1,0 +1,51 @@
+package religion
+
+import (
+	"github.com/nboughton/rollt"
+)
+
+// Evolution SWN Revised Free Edition p193
+var Evolution = rollt.List{
+	Name: "Evolution",
+	Items: []string{
+		"New holy book. Someone in the faith’s past penned or discovered a text that is now taken to be holy writ and the expressed will of the divine.",
+		"New prophet. This faith reveres the words and example of a relatively recent prophet, esteeming him or her as the final word on the will of God. The prophet may or may not still be living.",
+		"Syncretism. The faith has merged many of its beliefs with another religion. Roll again on the origin tradition table; this faith has reconciled the major elements of both beliefs into its tradition.",
+		"Neofundamentalism. The faith is fiercely resistant to perceived innovations and deviations from their beliefs. Even extremely onerous traditions and restrictions will be observed to the letter.",
+		"Quietism. The faith shuns the outside world and involvement with the affairs of nonbelievers. They prefer to keep to their own kind and avoid positions of wealth and power.",
+		"Sacrifices. The faith finds it necessary to make substantial sacrifices to please God. Some faiths may go so far as to offer human sacrifices, while others insist on huge tithes offered to the building of religious edifices.",
+		"Schism. The faith’s beliefs are actually almost identical to those of the majority of its origin tradition, save for a few minor points of vital interest to theologians and no practical difference whatsoever to believers. This does not prevent a burning resentment towards the parent faith.",
+		"Holy family. God’s favor has been shown especially to members of a particular lineage. It may be that only men and women of this bloodline are permitted to become clergy, or they may serve as helpless figureheads for the real leaders of the faith",
+	},
+}
+
+// OriginTradition SWN Revised Free Edition p193
+var OriginTradition = rollt.List{
+	Name: "Evolution",
+	Items: []string{
+		"Paganism",
+		"Roman Catholicism",
+		"Eastern Orthodox Christianity",
+		"Protestant Christianity",
+		"Buddhism",
+		"Judaism",
+		"Islam",
+		"Taoism",
+		"Hinduism",
+		"Zoroastrianism",
+		"Confucianism",
+		"Ideology",
+	},
+}
+
+// Leadership SWN Revised Free Edition p193
+var Leadership = rollt.Table{
+	Name: "Leadership",
+	Dice: "1d6",
+	Items: []rollt.Item{
+		{Match: []int{1, 2}, Text: "Patriarch/Matriarch. A single leader determines doctrine for the entire religion, possibly in consultation with other clerics."},
+		{Match: []int{3, 4}, Text: "Council. A group of the oldest and most revered clergy determine the course of the faith."},
+		{Match: []int{5}, Text: "Democracy. Every member has an equal voice in matters of faith, with doctrine usually decided at regular church- wide councils."},
+		{Match: []int{6}, Text: "No universal leadership. Roll again to determine how each region governs itself. If another 6 is rolled, this faith has no hierarchy."},
+	},
+}


### PR DESCRIPTION
Example output:

```console
$ swnt new religion
Evolution   :  Quietism. The faith shuns the outside world and involvement with the affairs of nonbelievers. They prefer to keep to their own kind and avoid positions of wealth and power.
Leadership  :  No universal leadership. Roll again to determine how each region governs itself. If another 6 is rolled, this faith has no hierarchy.
Evolution   :  Zoroastrianism
```